### PR TITLE
a much more thorough fix for 64 bit number encoding

### DIFF
--- a/lib/encode.js
+++ b/lib/encode.js
@@ -43,7 +43,7 @@ encode.bytes = function( buffers, data ) {
 }
 
 encode.number = function( buffers, data ) {
-  var maxLo = 4294967295
+  var maxLo = 0x80000000
   var hi = ( data / maxLo ) << 0
   var lo = ( data % maxLo  ) << 0
   var val = hi * maxLo + lo


### PR DESCRIPTION
hey guys, sorry it's taking two patches, but i did a much more thorough test of numbers and found that the previous implementation still has trouble with a certain set of numbers. anyhow, this should handle everything up to 2 ^ 53 (the effective max int in javascript)
