### PR TITLE
Fix encoding of large numbers

### DIFF
--- a/lib/encode.js
+++ b/lib/encode.js
@@ -63,21 +63,7 @@ encode.string = function (buffers, data) {
 }
 
 encode.number = function (buffers, data) {
-  var maxLo = 0x80000000
-  var hi = (data / maxLo) << 0
-  var lo = (data % maxLo) << 0
-  var val = hi * maxLo + lo
-
-  buffers.push(Buffer.from('i' + val + 'e'))
-
-  if (val !== data && !encode._floatConversionDetected) {
-    encode._floatConversionDetected = true
-    console.warn(
-      'WARNING: Possible data corruption detected with value "' + data + '":',
-      'Bencoding only defines support for integers, value was converted to "' + val + '"'
-    )
-    console.trace()
-  }
+  buffers.push(Buffer.from('i' + BigInt(data) + 'e'))
 }
 
 encode.dict = function (buffers, data) {

--- a/test/encode.test.js
+++ b/test/encode.test.js
@@ -182,4 +182,10 @@ test('bencode#encode()', function (t) {
     t.plan(1)
     t.deepEqual(result, expected)
   })
+
+  t.test('should encode large numbers with full digits', function (t) {
+    t.plan(1)
+    var data = 340282366920938463463374607431768211456
+    t.equal(bencode.encode(data).toString(), 'i340282366920938463463374607431768211456e')
+  })
 })


### PR DESCRIPTION
So, this is a fun one I noticed yesterday: Number.toString() can not be relied upon to give you all digits of an integer:

```js
// Number.toString()
> 340282366920938463463374607431768211456..toString()
'3.402823669209385e+38'

// Number.toPrecision() doesn't really help either
> 340282366920938463463374607431768211456..toPrecision(100)
'340282366920938463463374607431768211456.0000000000000000000000000000000000000000000000000000000000000'

// Neither does Number.toFixed()
> 340282366920938463463374607431768211456..toFixed(0)
'3.402823669209385e+38'

// Oh, look
> BigInt(340282366920938463463374607431768211456).toString()
'340282366920938463463374607431768211456'
```

While this is reasonably unlikely to happen in real-world usage as Number.toString() starts returning exponential notation at 2<sup>70</sup>, it still could occur, and considering this might be run on other engines than V8 which might have different limits, this could potentially occur sooner.

Unfortunately the only fix I found for this is going through `BigInt()` – I guess we could hand-roll something, but `BigInt()` seems to be the reliable thing to go for here – what do you think?