### PR TITLE
fix: Patch release to drop a dependecy to safe-buffer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,3 @@
-## 2.0.2
-
-- remove the safe-buffer dependency (@mmywarting)
-
 ## 2.0.1
 
 - fix deprecation warning on Buffer() constructor (@jhermsmeier)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
+## 2.0.2
+
+- remove the safe-buffer dependency (@mmywarting)
+
 ## 2.0.1
 
-- remove the safe-buffer dependency (@jimmywarting)
+- fix deprecation warning on Buffer() constructor (@jhermsmeier)
+- update dev depedencies (@jhermsmeier)
 
 ## 2.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.0.1
+
+- remove the safe-buffer dependency (@jimmywarting)
+
 ## 2.0.0
 
 - Drop support for Node 0.10, 0.12., add support for Node 8 & 9  (@jhermsmeier)

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -8,3 +8,4 @@ Sean Lang <slang800@gmail.com>
 Nicolas Gotchac <ngotchac@gmail.com>
 Feross Aboukhadijeh <feross@feross.org>
 Nazar Mokrynskyi <nazar@mokrynskyi.com>
+Jimmy Wärting <jimmy@warting.se>

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "bencode",
   "description": "Bencode de/encoder",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "bugs": {
     "url": "https://github.com/themasch/node-bencode/issues"
   },

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "bencode",
   "description": "Bencode de/encoder",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "bugs": {
     "url": "https://github.com/themasch/node-bencode/issues"
   },


### PR DESCRIPTION
safe-buffer is not required anymore since node v6 added the methods to the core.

Thanks to @jimmywarting for this patch!