### PR TITLE
fix benchmarks: replace nanobench with tinybench

### DIFF
--- a/benchmark/all.js
+++ b/benchmark/all.js
@@ -1,0 +1,5 @@
+import './bencode.js'
+import './buffer-vs-string.js'
+import './compare-decode.js'
+import './compare-encode.js'
+import './encoding-length.js'

--- a/benchmark/bencode.js
+++ b/benchmark/bencode.js
@@ -1,8 +1,12 @@
 import fs from 'fs'
 import path from 'path'
-import bench from 'nanobench'
+import { fileURLToPath } from 'url'
+import { Bench } from 'tinybench'
 
 import bencode from '../index.js'
+
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = path.dirname(__filename)
 
 const buffer = fs.readFileSync(path.join(__dirname, 'test.torrent'))
 const object = bencode.decode(buffer)
@@ -12,7 +16,9 @@ const objectBinary = bencode.decode(buffer, 'binary')
 
 const ITERATIONS = 10000
 
-bench(`bencode.encode() [buffer] ⨉ ${ITERATIONS}`, function (run) {
+const bench = new Bench({ time: 100 })
+
+bench.add(`bencode.encode() [buffer] ⨉ ${ITERATIONS}`, function (run) {
   let result = null
 
   run.start()
@@ -24,7 +30,7 @@ bench(`bencode.encode() [buffer] ⨉ ${ITERATIONS}`, function (run) {
   return result
 })
 
-bench(`bencode.encode() [utf8] ⨉ ${ITERATIONS}`, function (run) {
+bench.add(`bencode.encode() [utf8] ⨉ ${ITERATIONS}`, function (run) {
   let result = null
 
   run.start()
@@ -36,7 +42,7 @@ bench(`bencode.encode() [utf8] ⨉ ${ITERATIONS}`, function (run) {
   return result
 })
 
-bench(`bencode.encode() [ascii] ⨉ ${ITERATIONS}`, function (run) {
+bench.add(`bencode.encode() [ascii] ⨉ ${ITERATIONS}`, function (run) {
   let result = null
 
   run.start()
@@ -48,7 +54,7 @@ bench(`bencode.encode() [ascii] ⨉ ${ITERATIONS}`, function (run) {
   return result
 })
 
-bench(`bencode.encode() [binary] ⨉ ${ITERATIONS}`, function (run) {
+bench.add(`bencode.encode() [binary] ⨉ ${ITERATIONS}`, function (run) {
   let result = null
 
   run.start()
@@ -60,7 +66,7 @@ bench(`bencode.encode() [binary] ⨉ ${ITERATIONS}`, function (run) {
   return result
 })
 
-bench(`bencode.decode() [buffer] ⨉ ${ITERATIONS}`, function (run) {
+bench.add(`bencode.decode() [buffer] ⨉ ${ITERATIONS}`, function (run) {
   let result = null
 
   run.start()
@@ -72,7 +78,7 @@ bench(`bencode.decode() [buffer] ⨉ ${ITERATIONS}`, function (run) {
   return result
 })
 
-bench(`bencode.decode() [utf8] ⨉ ${ITERATIONS}`, function (run) {
+bench.add(`bencode.decode() [utf8] ⨉ ${ITERATIONS}`, function (run) {
   let result = null
 
   run.start()
@@ -84,7 +90,7 @@ bench(`bencode.decode() [utf8] ⨉ ${ITERATIONS}`, function (run) {
   return result
 })
 
-bench(`bencode.decode() [ascii] ⨉ ${ITERATIONS}`, function (run) {
+bench.add(`bencode.decode() [ascii] ⨉ ${ITERATIONS}`, function (run) {
   let result = null
 
   run.start()
@@ -96,7 +102,7 @@ bench(`bencode.decode() [ascii] ⨉ ${ITERATIONS}`, function (run) {
   return result
 })
 
-bench(`bencode.decode() [binary] ⨉ ${ITERATIONS}`, function (run) {
+bench.add(`bencode.decode() [binary] ⨉ ${ITERATIONS}`, function (run) {
   let result = null
 
   run.start()
@@ -107,3 +113,7 @@ bench(`bencode.decode() [binary] ⨉ ${ITERATIONS}`, function (run) {
 
   return result
 })
+
+await bench.run()
+
+console.table(bench.table())

--- a/benchmark/buffer-vs-string.js
+++ b/benchmark/buffer-vs-string.js
@@ -1,14 +1,21 @@
 import fs from 'fs'
 import path from 'path'
+import { fileURLToPath } from 'url'
 import bencode from '../index.js'
-import bench from 'nanobench'
+
+import { Bench } from 'tinybench'
+
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = path.dirname(__filename)
 
 const buffer = fs.readFileSync(path.join(__dirname, 'test.torrent'))
 const str = buffer.toString('ascii')
 
 const ITERATIONS = 10000
 
-bench(`decode buffer ⨉ ${ITERATIONS}`, function (run) {
+const bench = new Bench({ time: 100 })
+
+bench.add(`decode buffer ⨉ ${ITERATIONS}`, function (run) {
   let result = null
 
   run.start()
@@ -20,7 +27,7 @@ bench(`decode buffer ⨉ ${ITERATIONS}`, function (run) {
   return result
 })
 
-bench(`decode string ⨉ ${ITERATIONS}`, function (run) {
+bench.add(`decode string ⨉ ${ITERATIONS}`, function (run) {
   let result = null
 
   run.start()
@@ -31,3 +38,7 @@ bench(`decode string ⨉ ${ITERATIONS}`, function (run) {
 
   return result
 })
+
+await bench.run()
+
+console.table(bench.table())

--- a/benchmark/compare-decode.js
+++ b/benchmark/compare-decode.js
@@ -1,19 +1,26 @@
 import fs from 'fs'
 import path from 'path'
-import bench from 'nanobench'
+import { fileURLToPath } from 'url'
+import { Bench } from 'tinybench'
 
 import bencode from '../index.js'
+
 import bencoding from 'bencoding'
 import bncode from 'bncode'
 import btparse from 'btparse'
-import dht from 'dht.js/lib/dht/bencode'
+import dht from 'dht.js/lib/dht/bencode.js'
 import dhtBencode from 'dht-bencode'
+
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = path.dirname(__filename)
 
 const buffer = fs.readFileSync(path.join(__dirname, 'test.torrent'))
 
 const ITERATIONS = 10000
 
-bench(`bencode.decode() ⨉ ${ITERATIONS}`, function (run) {
+const bench = new Bench({ time: 100 })
+
+bench.add(`bencode.decode() ⨉ ${ITERATIONS}`, function (run) {
   let result = null
 
   run.start()
@@ -25,7 +32,7 @@ bench(`bencode.decode() ⨉ ${ITERATIONS}`, function (run) {
   return result
 })
 
-bench(`bencoding.decode() ⨉ ${ITERATIONS}`, function (run) {
+bench.add(`bencoding.decode() ⨉ ${ITERATIONS}`, function (run) {
   let result = null
 
   run.start()
@@ -37,7 +44,7 @@ bench(`bencoding.decode() ⨉ ${ITERATIONS}`, function (run) {
   return result
 })
 
-bench(`bncode.decode() ⨉ ${ITERATIONS}`, function (run) {
+bench.add(`bncode.decode() ⨉ ${ITERATIONS}`, function (run) {
   let result = null
 
   run.start()
@@ -49,7 +56,7 @@ bench(`bncode.decode() ⨉ ${ITERATIONS}`, function (run) {
   return result
 })
 
-bench(`btparse() ⨉ ${ITERATIONS}`, function (run) {
+bench.add(`btparse() ⨉ ${ITERATIONS}`, function (run) {
   let result = null
 
   run.start()
@@ -61,7 +68,7 @@ bench(`btparse() ⨉ ${ITERATIONS}`, function (run) {
   return result
 })
 
-bench(`dht.decode() ⨉ ${ITERATIONS}`, function (run) {
+bench.add(`dht.decode() ⨉ ${ITERATIONS}`, function (run) {
   let result = null
 
   run.start()
@@ -73,7 +80,7 @@ bench(`dht.decode() ⨉ ${ITERATIONS}`, function (run) {
   return result
 })
 
-bench(`dhtBencode.decode() ⨉ ${ITERATIONS}`, function (run) {
+bench.add(`dhtBencode.decode() ⨉ ${ITERATIONS}`, function (run) {
   let result = null
 
   run.start()
@@ -84,3 +91,7 @@ bench(`dhtBencode.decode() ⨉ ${ITERATIONS}`, function (run) {
 
   return result
 })
+
+await bench.run()
+
+console.table(bench.table())

--- a/benchmark/compare-encode.js
+++ b/benchmark/compare-encode.js
@@ -1,19 +1,26 @@
 import fs from 'fs'
 import path from 'path'
-import bench from 'nanobench'
+import { fileURLToPath } from 'url'
+import { Bench } from 'tinybench'
 
 import bencode from '../index.js'
+
 import bencoding from 'bencoding'
 import bncode from 'bncode'
-import dht from 'dht.js/lib/dht/bencode'
+import dht from 'dht.js/lib/dht/bencode.js'
 import dhtBencode from 'dht-bencode'
+
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = path.dirname(__filename)
 
 const buffer = fs.readFileSync(path.join(__dirname, 'test.torrent'))
 const object = bencode.decode(buffer)
 
 const ITERATIONS = 10000
 
-bench(`bencode.encode() ⨉ ${ITERATIONS}`, function (run) {
+const bench = new Bench({ time: 100 })
+
+bench.add(`bencode.encode() ⨉ ${ITERATIONS}`, function (run) {
   let result = null
 
   run.start()
@@ -25,7 +32,7 @@ bench(`bencode.encode() ⨉ ${ITERATIONS}`, function (run) {
   return result
 })
 
-bench(`bencoding.encode() ⨉ ${ITERATIONS}`, function (run) {
+bench.add(`bencoding.encode() ⨉ ${ITERATIONS}`, function (run) {
   let result = null
 
   run.start()
@@ -37,7 +44,7 @@ bench(`bencoding.encode() ⨉ ${ITERATIONS}`, function (run) {
   return result
 })
 
-bench(`bncode.encode() ⨉ ${ITERATIONS}`, function (run) {
+bench.add(`bncode.encode() ⨉ ${ITERATIONS}`, function (run) {
   let result = null
 
   run.start()
@@ -49,7 +56,7 @@ bench(`bncode.encode() ⨉ ${ITERATIONS}`, function (run) {
   return result
 })
 
-bench(`dht.encode() ⨉ ${ITERATIONS}`, function (run) {
+bench.add(`dht.encode() ⨉ ${ITERATIONS}`, function (run) {
   let result = null
 
   run.start()
@@ -61,7 +68,7 @@ bench(`dht.encode() ⨉ ${ITERATIONS}`, function (run) {
   return result
 })
 
-bench(`dhtBencode.encode() ⨉ ${ITERATIONS}`, function (run) {
+bench.add(`dhtBencode.encode() ⨉ ${ITERATIONS}`, function (run) {
   let result = null
 
   run.start()
@@ -72,3 +79,7 @@ bench(`dhtBencode.encode() ⨉ ${ITERATIONS}`, function (run) {
 
   return result
 })
+
+await bench.run()
+
+console.table(bench.table())

--- a/benchmark/encoding-length.js
+++ b/benchmark/encoding-length.js
@@ -1,14 +1,21 @@
 import fs from 'fs'
 import path from 'path'
+import { fileURLToPath } from 'url'
 import bencode from '../index.js'
-import bench from 'nanobench'
+
+import { Bench } from 'tinybench'
+
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = path.dirname(__filename)
 
 const buffer = fs.readFileSync(path.join(__dirname, 'test.torrent'))
 const torrent = bencode.decode(buffer)
 
 const ITERATIONS = 10000
 
-bench('bencode.encodingLength(torrent)', function (run) {
+const bench = new Bench({ time: 100 })
+
+bench.add('bencode.encodingLength(torrent)', function (run) {
   const result = null
 
   run.start()
@@ -20,7 +27,7 @@ bench('bencode.encodingLength(torrent)', function (run) {
   return result
 })
 
-bench('bencode.encodingLength(buffer)', function (run) {
+bench.add('bencode.encodingLength(buffer)', function (run) {
   const result = null
 
   run.start()
@@ -32,7 +39,7 @@ bench('bencode.encodingLength(buffer)', function (run) {
   return result
 })
 
-bench('bencode.encodingLength(string)', function (run) {
+bench.add('bencode.encodingLength(string)', function (run) {
   const result = null
 
   run.start()
@@ -44,7 +51,7 @@ bench('bencode.encodingLength(string)', function (run) {
   return result
 })
 
-bench('bencode.encodingLength(number)', function (run) {
+bench.add('bencode.encodingLength(number)', function (run) {
   const result = null
 
   run.start()
@@ -56,7 +63,7 @@ bench('bencode.encodingLength(number)', function (run) {
   return result
 })
 
-bench('bencode.encodingLength(array<number>)', function (run) {
+bench.add('bencode.encodingLength(array<number>)', function (run) {
   const result = null
 
   run.start()
@@ -68,7 +75,7 @@ bench('bencode.encodingLength(array<number>)', function (run) {
   return result
 })
 
-bench('bencode.encodingLength(small object)', function (run) {
+bench.add('bencode.encodingLength(small object)', function (run) {
   const result = null
 
   run.start()
@@ -79,3 +86,7 @@ bench('bencode.encodingLength(small object)', function (run) {
 
   return result
 })
+
+await bench.run()
+
+console.table(bench.table())

--- a/package.json
+++ b/package.json
@@ -26,11 +26,11 @@
     "btparse": "latest",
     "dht-bencode": "latest",
     "dht.js": "latest",
-    "nanobench": "3.0.0",
     "semantic-release": "21.1.1",
     "standard": "17.1.0",
     "tap-spec": "5.0.0",
-    "tape": "5.6.6"
+    "tape": "5.6.6",
+    "tinybench": "^2.5.0"
   },
   "keywords": [
     "bdecode",
@@ -51,7 +51,7 @@
     "url": "git://github.com/webtorrent/node-bencode.git"
   },
   "scripts": {
-    "benchmark": "nanobench benchmark/*.js",
+    "benchmark": "node benchmark/all.js",
     "bundle": "mkdir -p dist && npm run bundle:lib && npm run bundle:test",
     "bundle:lib": "browserify lib/index.js -s bencode -o dist/bencode.js",
     "bundle:test": "browserify test/*.test.js -o dist/tests.js",


### PR DESCRIPTION
## purpose

[ ] Documentation update
[x] Bug fix
[ ] New feature
[ ] Other

## before

```
$ npm run benchmark

> bencode@4.0.0 benchmark
> nanobench benchmark/*.js

/tmp/node-bencode/node_modules/nanobench/run.js:7
for (let i = 2; i < process.argv.length; i++) require(path.join(process.cwd(), process.argv[i]))
                                              ^

Error [ERR_REQUIRE_ESM]: require() of ES Module /tmp/node-bencode/benchmark/bencode.js from /tmp/node-bencode/node_modules/nanobench/run.js not supported.
Instead change the require of bencode.js in /tmp/node-bencode/nanobench/run.js to a dynamic import() which is available in all CommonJS modules.
    at Object.<anonymous> (/tmp/node-bencode/node_modules/nanobench/run.js:7:47) {
  code: 'ERR_REQUIRE_ESM'
}

Node.js v20.3.1
```

## after

```
$ npm run benchmark

> bencode@4.0.0 benchmark
> node benchmark/all.js

┌─────────┬─────────────────────────┬─────────┬────────────────────┬───────────┬─────────┐
│ (index) │        Task Name        │ ops/sec │ Average Time (ns)  │  Margin   │ Samples │
├─────────┼─────────────────────────┼─────────┼────────────────────┼───────────┼─────────┤
│    0    │ 'decode buffer ⨉ 10000' │ '3,109' │ 321637.03556612757 │ '±18.80%' │   311   │
│    1    │ 'decode string ⨉ 10000' │ '7,520' │ 132977.82539529787 │ '±1.35%'  │   753   │
└─────────┴─────────────────────────┴─────────┴────────────────────┴───────────┴─────────┘
┌─────────┬───────────────────────────────┬─────────┬────────────────────┬──────────┬─────────┐
│ (index) │           Task Name           │ ops/sec │ Average Time (ns)  │  Margin  │ Samples │
├─────────┼───────────────────────────────┼─────────┼────────────────────┼──────────┼─────────┤
│    0    │  'bencode.encode() ⨉ 10000'   │ '4,915' │ 203449.76826411922 │ '±4.16%' │   492   │
│    1    │ 'bencoding.encode() ⨉ 10000'  │ '7,867' │ 127099.88481359227 │ '±1.11%' │   787   │
│    2    │   'bncode.encode() ⨉ 10000'   │ '5,204' │ 192149.96678357848 │ '±1.63%' │   521   │
│    3    │    'dht.encode() ⨉ 10000'     │ '7,086' │ 141112.21156100123 │ '±2.91%' │   709   │
│    4    │ 'dhtBencode.encode() ⨉ 10000' │ '7,323' │ 136541.21890725088 │ '±1.50%' │   733   │
└─────────┴───────────────────────────────┴─────────┴────────────────────┴──────────┴─────────┘
┌─────────┬───────────────────────────────┬─────────┬────────────────────┬──────────┬─────────┐
│ (index) │           Task Name           │ ops/sec │ Average Time (ns)  │  Margin  │ Samples │
├─────────┼───────────────────────────────┼─────────┼────────────────────┼──────────┼─────────┤
│    0    │  'bencode.decode() ⨉ 10000'   │ '5,739' │  174245.10081886   │ '±3.51%' │   574   │
│    1    │ 'bencoding.decode() ⨉ 10000'  │ '7,735' │ 129266.9797744554  │ '±2.50%' │   774   │
│    2    │   'bncode.decode() ⨉ 10000'   │ '4,926' │ 202983.70483197257 │ '±1.43%' │   493   │
│    3    │      'btparse() ⨉ 10000'      │ '7,609' │  131418.479726443  │ '±1.24%' │   761   │
│    4    │    'dht.decode() ⨉ 10000'     │ '7,739' │ 129204.64933380598 │ '±1.09%' │   774   │
│    5    │ 'dhtBencode.decode() ⨉ 10000' │ '7,619' │ 131236.25250938997 │ '±1.86%' │   762   │
└─────────┴───────────────────────────────┴─────────┴────────────────────┴──────────┴─────────┘
┌─────────┬─────────────────────────────────────────┬─────────┬────────────────────┬──────────┬─────────┐
│ (index) │                Task Name                │ ops/sec │ Average Time (ns)  │  Margin  │ Samples │
├─────────┼─────────────────────────────────────────┼─────────┼────────────────────┼──────────┼─────────┤
│    0    │    'bencode.encodingLength(torrent)'    │ '6,646' │ 150445.01670321127 │ '±1.67%' │   665   │
│    1    │    'bencode.encodingLength(buffer)'     │ '7,696' │ 129933.3417570436  │ '±2.05%' │   770   │
│    2    │    'bencode.encodingLength(string)'     │ '6,143' │ 162767.33817123785 │ '±2.25%' │   615   │
│    3    │    'bencode.encodingLength(number)'     │ '7,701' │ 129849.4954362763  │ '±1.10%' │   771   │
│    4    │ 'bencode.encodingLength(array<number>)' │ '7,362' │ 135820.64856344194 │ '±2.03%' │   737   │
│    5    │ 'bencode.encodingLength(small object)'  │ '5,327' │ 187717.5960934408  │ '±2.38%' │   533   │
└─────────┴─────────────────────────────────────────┴─────────┴────────────────────┴──────────┴─────────┘
┌─────────┬─────────────────────────────────────┬─────────┬────────────────────┬──────────┬─────────┐
│ (index) │              Task Name              │ ops/sec │ Average Time (ns)  │  Margin  │ Samples │
├─────────┼─────────────────────────────────────┼─────────┼────────────────────┼──────────┼─────────┤
│    0    │ 'bencode.encode() [buffer] ⨉ 10000' │ '5,753' │ 173813.93081612058 │ '±5.72%' │   576   │
│    1    │  'bencode.encode() [utf8] ⨉ 10000'  │ '7,023' │ 142387.93446363122 │ '±2.26%' │   703   │
│    2    │ 'bencode.encode() [ascii] ⨉ 10000'  │ '7,672' │ 130327.47463633618 │ '±1.45%' │   768   │
│    3    │ 'bencode.encode() [binary] ⨉ 10000' │ '7,639' │ 130892.13633412468 │ '±1.32%' │   764   │
│    4    │ 'bencode.decode() [buffer] ⨉ 10000' │ '7,523' │ 132913.91433472652 │ '±2.12%' │   753   │
│    5    │  'bencode.decode() [utf8] ⨉ 10000'  │ '7,518' │ 133007.17764712393 │ '±1.22%' │   752   │
│    6    │ 'bencode.decode() [ascii] ⨉ 10000'  │ '6,617' │ 151124.20331315332 │ '±2.06%' │   662   │
│    7    │ 'bencode.decode() [binary] ⨉ 10000' │ '5,066' │ 197371.98131794526 │ '±2.27%' │   507   │
└─────────┴─────────────────────────────────────┴─────────┴────────────────────┴──────────┴─────────┘
```
