### PR TITLE
fix benchmarks: replace nanobench with bipbip

### DIFF
--- a/benchmark/benchmarks.js
+++ b/benchmark/benchmarks.js
@@ -1,0 +1,12 @@
+// workaround: name of first suite is not printed
+console.log('reference before benchmarks')
+
+import './reference-before.js'
+
+import './bencode.js'
+import './buffer-vs-string.js'
+import './compare-decode.js'
+import './compare-encode.js'
+import './encoding-length.js'
+
+import './reference-after.js'

--- a/benchmark/benchmarks.json
+++ b/benchmark/benchmarks.json
@@ -1,0 +1,237 @@
+{
+  "suites": [
+    {
+      "name": "reference before benchmarks",
+      "scenarios": [
+        {
+          "name": "fibonacci loop",
+          "executions": 1000000,
+          "time": 559.685652,
+          "error": 3.1487334028716933
+        },
+        {
+          "name": "fibonacci recursive",
+          "executions": 7934,
+          "time": 630177.2286362491,
+          "error": 1.0079477172579856
+        },
+        {
+          "name": "fibonacci recmemo",
+          "executions": 629322,
+          "time": 7945.0529029654135,
+          "error": 0.5723554930927267
+        }
+      ]
+    },
+    {
+      "name": "bencode",
+      "scenarios": [
+        {
+          "name": "bencode.encode() [buffer]",
+          "executions": 35127,
+          "time": 142342.0572494093,
+          "error": 1.2212460556968496
+        },
+        {
+          "name": "bencode.encode() [utf8]",
+          "executions": 1349,
+          "time": 3704002.3409933285,
+          "error": 0.6776323429925276
+        },
+        {
+          "name": "bencode.encode() [ascii]",
+          "executions": 1387,
+          "time": 3604457.93222783,
+          "error": 0.6959704620115251
+        },
+        {
+          "name": "bencode.encode() [binary]",
+          "executions": 1384,
+          "time": 3611082.62283237,
+          "error": 0.886904952461389
+        },
+        {
+          "name": "bencode.decode() [buffer]",
+          "executions": 42809,
+          "time": 116795.72767408722,
+          "error": 0.7320742513453905
+        },
+        {
+          "name": "bencode.decode() [utf8]",
+          "executions": 2313,
+          "time": 2161073.1547773452,
+          "error": 0.6380497099955478
+        },
+        {
+          "name": "bencode.decode() [ascii]",
+          "executions": 2409,
+          "time": 2074895.296803653,
+          "error": 0.5471675241633337
+        },
+        {
+          "name": "bencode.decode() [binary]",
+          "executions": 2396,
+          "time": 2086413.753338898,
+          "error": 0.5403395352166391
+        }
+      ]
+    },
+    {
+      "name": "buffer vs string",
+      "scenarios": [
+        {
+          "name": "decode buffer",
+          "executions": 45024,
+          "time": 111051.06445451315,
+          "error": 0.5052997397476986
+        },
+        {
+          "name": "decode string",
+          "executions": 27973,
+          "time": 178745.74042827013,
+          "error": 0.5037603579470834
+        }
+      ]
+    },
+    {
+      "name": "compare decode",
+      "scenarios": [
+        {
+          "name": "bencode.decode()",
+          "executions": 44568,
+          "time": 112188.04153204092,
+          "error": 0.5311823992431295
+        },
+        {
+          "name": "bencoding.decode()",
+          "executions": 54228,
+          "time": 92203.5159696098,
+          "error": 0.5519025773079677
+        },
+        {
+          "name": "bncode.decode()",
+          "executions": 1570,
+          "time": 3184351.9987261146,
+          "error": 4.031632965687692
+        },
+        {
+          "name": "btparse()",
+          "executions": 132325,
+          "time": 37785.48271301719,
+          "error": 0.49077930951590953
+        },
+        {
+          "name": "dht.decode()",
+          "executions": 47400,
+          "time": 105483.08683544304,
+          "error": 0.4728875447697615
+        },
+        {
+          "name": "dhtBencode.decode()",
+          "executions": 28774,
+          "time": 173762.59105442412,
+          "error": 0.4921701716738526
+        }
+      ]
+    },
+    {
+      "name": "compare encode",
+      "scenarios": [
+        {
+          "name": "bencode.encode()",
+          "executions": 37666,
+          "time": 132742.29127064196,
+          "error": 0.8299521400901717
+        },
+        {
+          "name": "bencoding.encode()",
+          "executions": 25,
+          "time": 195132381.92,
+          "error": 8.551313598927392
+        },
+        {
+          "name": "bncode.encode()",
+          "executions": 1,
+          "time": 3939521850,
+          "error": 0
+        },
+        {
+          "name": "dht.encode()",
+          "executions": 50,
+          "time": 99655056.16,
+          "error": 6.321304669124846
+        },
+        {
+          "name": "dhtBencode.encode()",
+          "executions": 14,
+          "time": 351528698.78571427,
+          "error": 9.904070184501599
+        }
+      ]
+    },
+    {
+      "name": "encoding length",
+      "scenarios": [
+        {
+          "name": "bencode.encodingLength(torrent)",
+          "executions": 162351,
+          "time": 30797.4295569476,
+          "error": 2.6093067216240846
+        },
+        {
+          "name": "bencode.encodingLength(buffer)",
+          "executions": 1000000,
+          "time": 1151.522846,
+          "error": 0.17154410205677803
+        },
+        {
+          "name": "bencode.encodingLength(string)",
+          "executions": 1000000,
+          "time": 4384.510143,
+          "error": 0.33437787838758865
+        },
+        {
+          "name": "bencode.encodingLength(number)",
+          "executions": 1000000,
+          "time": 557.416746,
+          "error": 0.29860269449773136
+        },
+        {
+          "name": "bencode.encodingLength(array<number>)",
+          "executions": 1000000,
+          "time": 2784.717913,
+          "error": 0.20104464676215553
+        },
+        {
+          "name": "bencode.encodingLength(small object)",
+          "executions": 311927,
+          "time": 16029.371202236422,
+          "error": 0.34310281585091806
+        }
+      ]
+    },
+    {
+      "name": "reference after benchmarks",
+      "scenarios": [
+        {
+          "name": "fibonacci loop",
+          "executions": 1000000,
+          "time": 689.084318,
+          "error": 0.231909777005114
+        },
+        {
+          "name": "fibonacci recursive",
+          "executions": 7080,
+          "time": 706143.8394067796,
+          "error": 0.963718658922282
+        },
+        {
+          "name": "fibonacci recmemo",
+          "executions": 614393,
+          "time": 8138.115209645944,
+          "error": 0.2215156965189563
+        }
+      ]
+    }
+  ]
+}

--- a/benchmark/bencode.js
+++ b/benchmark/bencode.js
@@ -1,8 +1,11 @@
 import fs from 'fs'
 import path from 'path'
-import bench from 'nanobench'
+import { fileURLToPath } from 'url'
 
 import bencode from '../index.js'
+
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = path.dirname(__filename)
 
 const buffer = fs.readFileSync(path.join(__dirname, 'test.torrent'))
 const object = bencode.decode(buffer)
@@ -10,100 +13,88 @@ const objectUtf8 = bencode.decode(buffer, 'utf8')
 const objectAscii = bencode.decode(buffer, 'ascii')
 const objectBinary = bencode.decode(buffer, 'binary')
 
-const ITERATIONS = 10000
+const ITERATIONS = 1
 
-bench(`bencode.encode() [buffer] ⨉ ${ITERATIONS}`, function (run) {
+suite('bencode', () => {
+
+scenario(`bencode.encode() [buffer]`, function () {
   let result = null
 
-  run.start()
   for (let i = 0; i < ITERATIONS; i++) {
     result = bencode.encode(object)
   }
-  run.end()
 
   return result
 })
 
-bench(`bencode.encode() [utf8] ⨉ ${ITERATIONS}`, function (run) {
+scenario(`bencode.encode() [utf8]`, function () {
   let result = null
 
-  run.start()
   for (let i = 0; i < ITERATIONS; i++) {
     result = bencode.encode(objectUtf8)
   }
-  run.end()
 
   return result
 })
 
-bench(`bencode.encode() [ascii] ⨉ ${ITERATIONS}`, function (run) {
+scenario(`bencode.encode() [ascii]`, function () {
   let result = null
 
-  run.start()
   for (let i = 0; i < ITERATIONS; i++) {
     result = bencode.encode(objectAscii)
   }
-  run.end()
 
   return result
 })
 
-bench(`bencode.encode() [binary] ⨉ ${ITERATIONS}`, function (run) {
+scenario(`bencode.encode() [binary]`, function () {
   let result = null
 
-  run.start()
   for (let i = 0; i < ITERATIONS; i++) {
     result = bencode.encode(objectBinary)
   }
-  run.end()
 
   return result
 })
 
-bench(`bencode.decode() [buffer] ⨉ ${ITERATIONS}`, function (run) {
+scenario(`bencode.decode() [buffer]`, function () {
   let result = null
 
-  run.start()
   for (let i = 0; i < ITERATIONS; i++) {
     result = bencode.decode(buffer)
   }
-  run.end()
 
   return result
 })
 
-bench(`bencode.decode() [utf8] ⨉ ${ITERATIONS}`, function (run) {
+scenario(`bencode.decode() [utf8]`, function () {
   let result = null
 
-  run.start()
   for (let i = 0; i < ITERATIONS; i++) {
     result = bencode.decode(buffer, 'utf8')
   }
-  run.end()
 
   return result
 })
 
-bench(`bencode.decode() [ascii] ⨉ ${ITERATIONS}`, function (run) {
+scenario(`bencode.decode() [ascii]`, function () {
   let result = null
 
-  run.start()
   for (let i = 0; i < ITERATIONS; i++) {
     result = bencode.decode(buffer, 'ascii')
   }
-  run.end()
 
   return result
 })
 
-bench(`bencode.decode() [binary] ⨉ ${ITERATIONS}`, function (run) {
+scenario(`bencode.decode() [binary]`, function () {
   let result = null
 
-  run.start()
   for (let i = 0; i < ITERATIONS; i++) {
     result = bencode.decode(buffer, 'binary')
   }
-  run.end()
 
   return result
+})
+
 })

--- a/benchmark/buffer-vs-string.js
+++ b/benchmark/buffer-vs-string.js
@@ -1,33 +1,36 @@
 import fs from 'fs'
 import path from 'path'
+import { fileURLToPath } from 'url'
 import bencode from '../index.js'
-import bench from 'nanobench'
+
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = path.dirname(__filename)
 
 const buffer = fs.readFileSync(path.join(__dirname, 'test.torrent'))
 const str = buffer.toString('ascii')
 
-const ITERATIONS = 10000
+const ITERATIONS = 1
 
-bench(`decode buffer ⨉ ${ITERATIONS}`, function (run) {
+suite('buffer vs string', () => {
+
+scenario(`decode buffer`, function () {
   let result = null
 
-  run.start()
   for (let i = 0; i < ITERATIONS; i++) {
     result = bencode.decode(buffer)
   }
-  run.end()
 
   return result
 })
 
-bench(`decode string ⨉ ${ITERATIONS}`, function (run) {
+scenario(`decode string`, function () {
   let result = null
 
-  run.start()
   for (let i = 0; i < ITERATIONS; i++) {
     result = bencode.decode(str)
   }
-  run.end()
 
   return result
+})
+
 })

--- a/benchmark/compare-decode.js
+++ b/benchmark/compare-decode.js
@@ -1,86 +1,82 @@
 import fs from 'fs'
 import path from 'path'
-import bench from 'nanobench'
+import { fileURLToPath } from 'url'
 
 import bencode from '../index.js'
+
 import bencoding from 'bencoding'
 import bncode from 'bncode'
 import btparse from 'btparse'
-import dht from 'dht.js/lib/dht/bencode'
+import dht from 'dht.js/lib/dht/bencode.js'
 import dhtBencode from 'dht-bencode'
+
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = path.dirname(__filename)
 
 const buffer = fs.readFileSync(path.join(__dirname, 'test.torrent'))
 
-const ITERATIONS = 10000
+const ITERATIONS = 1
 
-bench(`bencode.decode() ⨉ ${ITERATIONS}`, function (run) {
+suite('compare decode', () => {
+
+scenario(`bencode.decode()`, function () {
   let result = null
 
-  run.start()
   for (let i = 0; i < ITERATIONS; i++) {
     result = bencode.decode(buffer)
   }
-  run.end()
 
   return result
 })
 
-bench(`bencoding.decode() ⨉ ${ITERATIONS}`, function (run) {
+scenario(`bencoding.decode()`, function () {
   let result = null
 
-  run.start()
   for (let i = 0; i < ITERATIONS; i++) {
     result = bencoding.decode(buffer)
   }
-  run.end()
 
   return result
 })
 
-bench(`bncode.decode() ⨉ ${ITERATIONS}`, function (run) {
+scenario(`bncode.decode()`, function () {
   let result = null
 
-  run.start()
   for (let i = 0; i < ITERATIONS; i++) {
     result = bncode.decode(buffer)
   }
-  run.end()
 
   return result
 })
 
-bench(`btparse() ⨉ ${ITERATIONS}`, function (run) {
+scenario(`btparse()`, function () {
   let result = null
 
-  run.start()
   for (let i = 0; i < ITERATIONS; i++) {
     result = btparse(buffer)
   }
-  run.end()
 
   return result
 })
 
-bench(`dht.decode() ⨉ ${ITERATIONS}`, function (run) {
+scenario(`dht.decode()`, function () {
   let result = null
 
-  run.start()
   for (let i = 0; i < ITERATIONS; i++) {
     result = dht.decode(buffer)
   }
-  run.end()
 
   return result
 })
 
-bench(`dhtBencode.decode() ⨉ ${ITERATIONS}`, function (run) {
+scenario(`dhtBencode.decode()`, function () {
   let result = null
 
-  run.start()
   for (let i = 0; i < ITERATIONS; i++) {
     result = dhtBencode.bdecode(buffer)
   }
-  run.end()
 
   return result
+})
+
 })

--- a/benchmark/compare-encode.js
+++ b/benchmark/compare-encode.js
@@ -1,74 +1,72 @@
 import fs from 'fs'
 import path from 'path'
-import bench from 'nanobench'
+import { fileURLToPath } from 'url'
 
 import bencode from '../index.js'
+
 import bencoding from 'bencoding'
 import bncode from 'bncode'
-import dht from 'dht.js/lib/dht/bencode'
+import dht from 'dht.js/lib/dht/bencode.js'
 import dhtBencode from 'dht-bencode'
+
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = path.dirname(__filename)
 
 const buffer = fs.readFileSync(path.join(__dirname, 'test.torrent'))
 const object = bencode.decode(buffer)
 
-const ITERATIONS = 10000
+const ITERATIONS = 1
 
-bench(`bencode.encode() ⨉ ${ITERATIONS}`, function (run) {
+suite('compare encode', () => {
+
+scenario(`bencode.encode()`, function () {
   let result = null
 
-  run.start()
   for (let i = 0; i < ITERATIONS; i++) {
     result = bencode.encode(object)
   }
-  run.end()
 
   return result
 })
 
-bench(`bencoding.encode() ⨉ ${ITERATIONS}`, function (run) {
+scenario(`bencoding.encode()`, function () {
   let result = null
 
-  run.start()
   for (let i = 0; i < ITERATIONS; i++) {
     result = bencoding.encode(object)
   }
-  run.end()
 
   return result
 })
 
-bench(`bncode.encode() ⨉ ${ITERATIONS}`, function (run) {
+scenario(`bncode.encode()`, function () {
   let result = null
 
-  run.start()
   for (let i = 0; i < ITERATIONS; i++) {
     result = bncode.encode(object)
   }
-  run.end()
 
   return result
 })
 
-bench(`dht.encode() ⨉ ${ITERATIONS}`, function (run) {
+scenario(`dht.encode()`, function () {
   let result = null
 
-  run.start()
   for (let i = 0; i < ITERATIONS; i++) {
     result = dht.encode(object)
   }
-  run.end()
 
   return result
 })
 
-bench(`dhtBencode.encode() ⨉ ${ITERATIONS}`, function (run) {
+scenario(`dhtBencode.encode()`, function () {
   let result = null
 
-  run.start()
   for (let i = 0; i < ITERATIONS; i++) {
     result = dhtBencode.bencode(object)
   }
-  run.end()
 
   return result
+})
+
 })

--- a/benchmark/encoding-length.js
+++ b/benchmark/encoding-length.js
@@ -1,81 +1,76 @@
 import fs from 'fs'
 import path from 'path'
+import { fileURLToPath } from 'url'
 import bencode from '../index.js'
-import bench from 'nanobench'
+
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = path.dirname(__filename)
 
 const buffer = fs.readFileSync(path.join(__dirname, 'test.torrent'))
 const torrent = bencode.decode(buffer)
 
-const ITERATIONS = 10000
+const ITERATIONS = 1
 
-bench('bencode.encodingLength(torrent)', function (run) {
+suite('encoding length', () => {
+
+scenario('bencode.encodingLength(torrent)', function () {
   const result = null
 
-  run.start()
   for (let i = 0; i < ITERATIONS; i++) {
     bencode.encodingLength(torrent)
   }
-  run.end()
 
   return result
 })
 
-bench('bencode.encodingLength(buffer)', function (run) {
+scenario('bencode.encodingLength(buffer)', function () {
   const result = null
 
-  run.start()
   for (let i = 0; i < ITERATIONS; i++) {
     bencode.encodingLength(buffer)
   }
-  run.end()
 
   return result
 })
 
-bench('bencode.encodingLength(string)', function (run) {
+scenario('bencode.encodingLength(string)', function () {
   const result = null
 
-  run.start()
   for (let i = 0; i < ITERATIONS; i++) {
     bencode.encodingLength('Test, test, this is a string')
   }
-  run.end()
 
   return result
 })
 
-bench('bencode.encodingLength(number)', function (run) {
+scenario('bencode.encodingLength(number)', function () {
   const result = null
 
-  run.start()
   for (let i = 0; i < ITERATIONS; i++) {
     bencode.encodingLength(87641234567)
   }
-  run.end()
 
   return result
 })
 
-bench('bencode.encodingLength(array<number>)', function (run) {
+scenario('bencode.encodingLength(array<number>)', function () {
   const result = null
 
-  run.start()
   for (let i = 0; i < ITERATIONS; i++) {
     bencode.encodingLength([0, 1, 2, 3, 4, 5, 6, 7, 8, 9])
   }
-  run.end()
 
   return result
 })
 
-bench('bencode.encodingLength(small object)', function (run) {
+scenario('bencode.encodingLength(small object)', function () {
   const result = null
 
-  run.start()
   for (let i = 0; i < ITERATIONS; i++) {
     bencode.encodingLength({ a: 1, b: 'c', d: 'abcdefg', e: [1, 2, 3] })
   }
-  run.end()
 
   return result
+})
+
 })

--- a/benchmark/fibonacci.js
+++ b/benchmark/fibonacci.js
@@ -1,0 +1,42 @@
+// run a constant benchmark suite before and after our tests
+// so we can normalize performance across different CPUs
+
+// bipbip/__benchmarks__/fibonacci.js
+
+export function fibonacciSuite(name) {
+
+  function loop(input) {
+      let num = input
+      let a = 1
+      let b = 0
+      let temp
+      while (num >= 0) {
+          temp = a
+          a += b
+          b = temp
+          num -= 1
+      }
+      return b
+  }
+
+  function recursive(num) {
+      if (num <= 1) return 1
+      return recursive(num - 1) + recursive(num - 2)
+  }
+
+  function recmemo(num, memo = {}) {
+      if (memo[num]) return memo[num]
+      if (num <= 1) return 1
+      memo[num] =
+          recmemo(num - 1, memo) +
+          recmemo(num - 2, memo)
+      return memo[num]
+  }
+
+  suite(name, () => {
+      const input = 20
+      scenario('fibonacci loop', () => { loop(input) })
+      scenario('fibonacci recursive', () => { recursive(input) })
+      scenario('fibonacci recmemo', () => { recmemo(input) })
+  })
+}

--- a/benchmark/reference-after.js
+++ b/benchmark/reference-after.js
@@ -1,0 +1,3 @@
+import { fibonacciSuite } from './fibonacci.js'
+
+fibonacciSuite('reference after benchmarks')

--- a/benchmark/reference-before.js
+++ b/benchmark/reference-before.js
@@ -1,0 +1,4 @@
+import { fibonacciSuite } from './fibonacci.js'
+
+fibonacciSuite('reference before benchmarks')
+

--- a/package.json
+++ b/package.json
@@ -21,12 +21,12 @@
   "devDependencies": {
     "@webtorrent/semantic-release-config": "1.0.10",
     "bencoding": "latest",
+    "bipbip": "github:milahu/bipbip",
     "bncode": "latest",
     "browserify": "^17.0.0",
     "btparse": "latest",
     "dht-bencode": "latest",
     "dht.js": "latest",
-    "nanobench": "3.0.0",
     "semantic-release": "21.1.1",
     "standard": "17.1.0",
     "tap-spec": "5.0.0",
@@ -51,7 +51,8 @@
     "url": "git://github.com/webtorrent/node-bencode.git"
   },
   "scripts": {
-    "benchmark": "nanobench benchmark/*.js",
+    "benchmark": "bipbip --compare benchmark/benchmarks.json --save benchmark/benchmarks.json benchmark/benchmarks.js",
+    "benchmark-nosave": "bipbip --compare benchmark/benchmarks.json benchmark/benchmarks.js",
     "bundle": "mkdir -p dist && npm run bundle:lib && npm run bundle:test",
     "bundle:lib": "browserify lib/index.js -s bencode -o dist/bencode.js",
     "bundle:test": "browserify test/*.test.js -o dist/tests.js",


### PR DESCRIPTION
## purpose

[ ] Documentation update
[x] Bug fix
[ ] New feature
[ ] Other

alternative to #164

## before

```
$ npm run benchmark

> bencode@4.0.0 benchmark
> nanobench benchmark/*.js

/tmp/node-bencode/node_modules/nanobench/run.js:7
for (let i = 2; i < process.argv.length; i++) require(path.join(process.cwd(), process.argv[i]))
                                              ^

Error [ERR_REQUIRE_ESM]: require() of ES Module /tmp/node-bencode/benchmark/bencode.js from /tmp/node-bencode/node_modules/nanobench/run.js not supported.
Instead change the require of bencode.js in /tmp/node-bencode/nanobench/run.js to a dynamic import() which is available in all CommonJS modules.
    at Object.<anonymous> (/tmp/node-bencode/node_modules/nanobench/run.js:7:47) {
  code: 'ERR_REQUIRE_ESM'
}

Node.js v20.3.1
```

## after

```
$ npm run benchmark

> bencode@4.0.0 benchmark
> bipbip --compare benchmark/benchmarks.json --save benchmark/benchmarks.json benchmark/benchmarks.js

reference before benchmarks
  ✔ fibonacci loop: 1,786,717 ops/sec (±3.15%, ⨉1000000)
  ✔ fibonacci recursive: 1,586 ops/sec (±1.01%, ⨉7934)
  ✔ fibonacci recmemo: 125,864 ops/sec (±0.57%, ⨉629322)

bencode
  ✔ bencode.encode() [buffer]: 7,025 ops/sec (±1.22%, ⨉35127)
  ✔ bencode.encode() [utf8]: 269 ops/sec (±0.68%, ⨉1349)
  ✔ bencode.encode() [ascii]: 277 ops/sec (±0.70%, ⨉1387)
  ✔ bencode.encode() [binary]: 276 ops/sec (±0.89%, ⨉1384)
  ✔ bencode.decode() [buffer]: 8,561 ops/sec (±0.73%, ⨉42809)
  ✔ bencode.decode() [utf8]: 462 ops/sec (±0.64%, ⨉2313)
  ✔ bencode.decode() [ascii]: 481 ops/sec (±0.55%, ⨉2409)
  ✔ bencode.decode() [binary]: 479 ops/sec (±0.54%, ⨉2396)

buffer vs string
  ✔ decode buffer: 9,004 ops/sec (±0.51%, ⨉45024)
  ✔ decode string: 5,594 ops/sec (±0.50%, ⨉27973)

compare decode
  ✔ bencode.decode(): 8,913 ops/sec (±0.53%, ⨉44568)
  ✔ bencoding.decode(): 10,845 ops/sec (±0.55%, ⨉54228)
  ✔ bncode.decode(): 314 ops/sec (±4.03%, ⨉1570)
  ✔ btparse(): 26,465 ops/sec (±0.49%, ⨉132325)
  ✔ dht.decode(): 9,480 ops/sec (±0.47%, ⨉47400)
  ✔ dhtBencode.decode(): 5,754 ops/sec (±0.49%, ⨉28774)

compare encode
  ✔ bencode.encode(): 7,533 ops/sec (±0.83%, ⨉37666)
  ✔ bencoding.encode(): 5 ops/sec (±8.55%, ⨉25)
  ✔ bncode.encode(): 3.9s per call (±0.00%, ⨉1)
  ✔ dht.encode(): 10 ops/sec (±6.32%, ⨉50)
  ✔ dhtBencode.encode(): 2 ops/sec (±9.90%, ⨉14)

encoding length
  ✔ bencode.encodingLength(torrent): 32,470 ops/sec (±2.61%, ⨉162351)
  ✔ bencode.encodingLength(buffer): 868,415 ops/sec (±0.17%, ⨉1000000)
  ✔ bencode.encodingLength(string): 228,075 ops/sec (±0.33%, ⨉1000000)
  ✔ bencode.encodingLength(number): 1,793,989 ops/sec (±0.30%, ⨉1000000)
  ✔ bencode.encodingLength(array<number>): 359,102 ops/sec (±0.20%, ⨉1000000)
  ✔ bencode.encodingLength(small object): 62,385 ops/sec (±0.34%, ⨉311927)

reference after benchmarks
  ✔ fibonacci loop: 1,451,201 ops/sec (±0.23%, ⨉1000000)
  ✔ fibonacci recursive: 1,416 ops/sec (±0.96%, ⨉7080)
  ✔ fibonacci recmemo: 122,878 ops/sec (±0.22%, ⨉614393)

Result:    0.00%   
Suites:    7 total 
Scenarios: 33 total
Time:      2m 45.7s
```
