### PR TITLE
fix: sort dictionary keys bytewise per BEP 3

### DIFF
--- a/lib/encode.js
+++ b/lib/encode.js
@@ -74,13 +74,23 @@ encode.number = function (buffers, data) {
   }
 }
 
+function compareKeysByBytes (a, b) {
+  const ab = ArrayBuffer.isView(a) ? a : text2arr(String(a))
+  const bb = ArrayBuffer.isView(b) ? b : text2arr(String(b))
+  const length = Math.min(ab.length, bb.length)
+  for (let i = 0; i < length; i++) {
+    if (ab[i] !== bb[i]) return ab[i] - bb[i]
+  }
+  return ab.length - bb.length
+}
+
 encode.dict = function (buffers, data) {
   buffers.push(buffD)
 
   let j = 0
   let k
   // fix for issue #13 - sorted dicts
-  const keys = Object.keys(data).sort()
+  const keys = Object.keys(data).sort(compareKeysByBytes)
   const kl = keys.length
 
   for (; j < kl; j++) {
@@ -96,7 +106,7 @@ encode.dict = function (buffers, data) {
 encode.dictMap = function (buffers, data) {
   buffers.push(buffD)
 
-  const keys = Array.from(data.keys()).sort()
+  const keys = Array.from(data.keys()).sort(compareKeysByBytes)
 
   for (const key of keys) {
     if (data.get(key) == null) continue

--- a/test/encode.test.js
+++ b/test/encode.test.js
@@ -22,6 +22,14 @@ test('bencode#encode()', function (t) {
     t.equal(Buffer.from(bencode.encode(data)).toString(), 'd7:integeri12345e6:string11:Hello Worlde')
   })
 
+  t.test('should sort dictionary keys bytewise per BEP 3, including astral keys', function (t) {
+    t.plan(1)
+    // '\uE000' (UTF-8 ee 80 80) must sort before '\u{1F600}' (UTF-8 f0 9f 98 80),
+    // even though the astral key's leading UTF-16 surrogate (d83d) sorts first.
+    const data = { '\u{1F600}': 2, '\uE000': 1 }
+    t.equal(Buffer.from(bencode.encode(data)).toString('hex'), '64333aee8080693165343af09f988069326565')
+  })
+
   t.test('should force keys to be strings', function (t) {
     t.plan(1)
     const data = {


### PR DESCRIPTION
`encode.dict` and `encode.dictMap` sort keys with `Array.prototype.sort()`, which orders by **UTF-16 code unit**. BEP 3 requires dictionary keys to "appear in sorted order (sorted as raw strings, not alphanumerics)" — i.e. bytewise on their UTF-8 encoding (the repo's own `test/specifications.md` states this).

The two orderings diverge for keys containing an **astral (non-BMP) code point**: its leading UTF-16 surrogate (`0xD800`–`0xDBFF`) sorts *before* a BMP key in `U+E000`–`U+FFFF`, but its first UTF-8 byte (`0xF0`+) sorts *after* that key's `0xEE`/`0xEF` byte — so the order inverts.

```js
const d = {}
d['\u{1F600}'] = 2   // UTF-8: f0 9f 98 80
d['']   = 1   // UTF-8: ee 80 80
bencode.encode(d)
// emits  d 4:<f0 9f 98 80> i2e 3:<ee 80 80> i1e e   (astral first — non-canonical)
// BEP 3  d 3:<ee 80 80> i1e 4:<f0 9f 98 80> i2e e   (ee < f0)
```

### Impact
A torrent **info-hash is SHA-1 of the bencoded `info` dictionary**, so a dict whose keys trip this inversion produces a non-canonical encoding and a **wrong info-hash** (`28d6de08…` vs the canonical `408ec594…` for the example above). Ordinary torrents are unaffected — their keys are ASCII/BMP — but `bencode` is a general-purpose deterministic serializer (content-addressing, DHT values, arbitrary metadata), and any astral-codepoint key (emoji, CJK Ext-B, rare scripts) yields non-canonical output.

### Fix
Sort by the bytes that are actually emitted — the UTF-8 encoding for string/number keys, the raw bytes for `Buffer` keys (matching how `encode.dict`/`encode.dictMap` write the keys). Fuzzing (200k adversarial key sets) shows all non-canonical orderings on the current code involve astral keys; with the fix, 0 remain, and byte-sort is identical to the default sort for the all-BMP case.

### Tests
Added a case asserting bytewise order for an astral + BMP key pair. It fails on the current code and passes with the fix. The full suite (421 → 422) is green and the bundled `benchmark/test.torrent` still re-encodes byte-identically.
