### PR TITLE
fix: correct exports field to use subpath "." with import condition

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,9 @@
     "node": ">=12.20.0"
   },
   "exports": {
-    "import": "./index.js"
+    ".": {
+      "import": "./index.js"
+    }
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
The current `exports` field:

```json
"exports": {
  "import": "./index.js"
}
```

Treats `"import"` as a **subpath** (`bencode/import`), not as a condition. The package root entry point (`import "bencode"`) is left undefined because there is no `"."` subpath.

This PR wraps the condition inside `"."` so that `"import"` becomes a proper condition on the root export:

```json
"exports": {
  ".": {
    "import": "./index.js"
  }
}
```

This correctly declares an ESM-only package root entry while keeping the same restriction.